### PR TITLE
Add Council election process.

### DIFF
--- a/BY_LAWS.md
+++ b/BY_LAWS.md
@@ -1,0 +1,41 @@
+# Thunderbird Council By-Laws
+
+## Thunderbird Council Election Process
+
+The current election process is detailed below.
+
+1. A list of persons eligible to vote (the "electors") shall be established by the existing Council, see the section entitled “Electorate” below for how this is done. The names of the electors will be made public.
+2. The list of electors will be entered into a private mailing list (currently known as tb-election) that will be created for the purpose of managing the Thunderbird Council election. All people with voting rights will be added to that list, and any discussion of the nominees and candidates, and any specific instructions on how to vote, will be distributed through that list and only through that list. Once the discussion period has started, all members of the list can post freely to the list (subject only to moderation for abusive posts) to discuss any issues relevant to the election.
+3. Persons on the electorate list who desire to stand for election should send their self-announcement to the list, titled: “Standing for Election: <name>”, stating in the body of the email:
+   1. name;
+   2. current professional affiliation (if any);
+   3. a statement summarising their contributions to Thunderbird; and
+   4. a personal statement.
+4. It is the responsibility of the person desiring to stand to make sure their message makes it to the list. No late self-announcements will be accepted for any reason.
+5. In the case there are more than two people nominated from the same professional affiliation, a pre-election will take place first, and the two winners will continue to the real election. The 'Mozilla Corporation', the 'Mozilla Foundation', and ‘MZLA Technologies’ are (considered) separate companies for purposes of "professional affiliation”.
+6. Electors shall vote for Council members from the list of those standing for election, with the specific method and process selected by a neutral third-party observer.
+7. The voting process shall select a Council of seven members, each with a one-year term. Voting will occur on an external, secure voting-as-a-service platform. If more than seven people stand for election, voting will be done using “ranked choice”, with conversion of the individual choices into an elected council done using the Scottish STV method. If seven or fewer persons stand for election, then the voting shall consist of a simple yes or no to accept or decline the entire slate as the elected Council.
+
+### Electorate
+
+Contributors are eligible to vote in Thunderbird Council elections if they fulfill the following requirements:
+
+> Elector qualification is 10 hours of contribution per year of involvement in the project, with a three year look back. Thus, if someone first became involved: three years ago then the expected contribution is at least 30 hours, if two years ago then at least 20 hours, and if one year ago or less then at least 10 hours. Contributors may self-nominate, and on request must submit examples that illustrate their level of involvement.
+
+### Schedule & Timeline
+
+Below is a rough timeline of the events that should happen, the community should be kept up-to-date for each of these events.
+
+* Electoral roll created and published
+* Announce the electoral roll
+* Self-nominations to electoral roll: 1 week
+* Voter list finalised & mailing list established
+* Self-nomination period: 1 week
+* Discussion period: 1 week
+* (Potentially) Pre-election voting emails sent out, if more than 2 nominations from the same professional affiliation
+* (Potentially) Pre-election voting is open: 1 week
+* Voting emails sent out
+* Voting is open: 1 week
+* Voting closes
+* Results announced
+* New Council takes effect


### PR DESCRIPTION
Per the [passed motion from 2022-08-01](https://thunderbird.topicbox.com/groups/planning/T8e46dbe1949f8373-M1fb502009ff688611cffd847):

> Motion: Add [Thunderbird Election Process](https://wiki.mozilla.org/Thunderbird/Council_Election) (as mentioned on that Wiki page) to the council-docs repository, as the start of a Thunderbird Council bylaws document.
>
> * Proposed by Patrick, seconded by Dirk
> * YES: Ben, Berna, Dirk, Patrick
> * NO: -
> * Absent: Andrei, Magnus, Philipp
> * The motion PASSED

This is converted to markdown with a minor change (to refer to using generic mailing lists instead of mailman) and re-ordering the sub-headings as in the original email.