### PR TITLE
Add 2023-2024 Election roll

### DIFF
--- a/electoral_rolls/2023.md
+++ b/electoral_rolls/2023.md
@@ -1,0 +1,163 @@
+Electoral roll as of January 10, 2024.
+
+* Aceman
+* Achim Seufert
+* AE Creations
+* Alessandro Castellani
+* Alexander Bergmann
+* Alexander Ihrig
+* Alexander Moisseev
+* Alexander Shutau
+* Alfred Peters
+* Alice White
+* Alta88
+* Andre Klapper
+* Andreas
+* Andrei Hajdukewycz
+* Andrew Sutherland
+* Andrew Van Tassel
+* Anje Yelf
+* Arnd Issler
+* Arthur K.
+* Aureliano Buendía
+* Axel Grude
+* B.J. Herbison
+* Beltrachi
+* Ben Bucksch
+* Ben Campbell
+* Berna Alp
+* Besnik Bleta
+* Besnik Bleta
+* Brendan Abolivier
+* Brian Behlendorf
+* Brummolix
+* C-E
+* caligraf
+* Calum Mackay
+* Caspy7
+* Charles Tanstaafl
+* Chiaki Ishikawa
+* Chris Ilias
+* Chris Schiffner
+* Christian Riechers
+* Christopher Leidigh
+* cketti
+* ClearCode Inc.
+* ctrlxc
+* Dan Pernokis
+* Daniel Darnell
+* Danny Colin
+* David :Bienvenu
+* DeltaBlast
+* Dillinger
+* Dirk Steinmetz
+* DisplayName1234
+* Dossy Shiobara
+* dreadnaut
+* Dugite-Code
+* Eckard Berberich
+* Elizabeth Mitchell
+* Emilio Cobos Álvarez
+* Emmanuel ROECKER
+* Era
+* Erosman
+* Florent Tassy
+* Franz Josef Wechselberger
+* Gene Smith
+* Geoff Lankow
+* Günter Gersdorf
+* H.Ogi
+* Hartmut Welpmann [:welpy-cw]
+* Heather Ellsworth
+* Heinz Drexler
+* Henry Wilkes
+* Ikey Dohortey
+* Itagaki Fumihiko
+* Jan Kiszka
+* Jason Evangelho
+* Jason Siefken
+* Jeevanandam M.
+* Jefferson Scher
+* Jens Dede
+* Jim Porter
+* Jirí Lýsek
+* Joaquín Serna
+* Johannes Endres
+* John Bieling
+* Jonathan Kamens
+* Jordi Sanfeliu Font
+* Joshua Cranmer
+* Juraj Mäsiar
+* Kai Engert
+* kenjiuno
+* kxxt
+* LanguageTooler GmbH
+* Lasana Murray
+* ldreier
+* Leon Wolfgang Rönnpagel
+* Lisa McCormack
+* Lucas Bonomo
+* M Lopez-Ibanez
+* Magnus Melin
+* Marco Zanon
+* Mark Banner
+* Markus Pullmann
+* Martin Giger
+* Martin Schröder
+* Martins Lazdans
+* Masatoshi Kimura
+* Matt Harris
+* Matthias
+* Meatian
+* Micah Ilbery
+* Michael Ganss
+* Michal Stanke
+* Michele Rodaro
+* Mike Conley
+* Mohamed Farahat
+* Neil Bird
+* Neil Rashbrook
+* Nicolas Mandil (:NicolasWeb)
+* NilsKr33
+* Nomis101
+* Onno Ekker
+* opto
+* OR
+* Patrick Cloke
+* Peter Pin-Guang Chen
+* Philipp Kewisch
+* Philippe Lieser
+* Philippe Vigneau
+* Phoenix
+* Ping Chen
+* Raymond Hill
+* Rhoslyn Prys
+* Richard Marti
+* Rob Lemley
+* Robert Kaiser
+* Robert Longson [:longsonr]
+* Roland Tanglao
+* Ryan Lee
+* Ryan Sipes
+* Saverio Morelli
+* Sean Burke
+* SECUSO
+* Simon Arlott
+* Solange
+* Sören Hentzschel
+* Takayama Fumihiko
+* tandemjump
+* Teal Dulcet
+* The Stonehead
+* Theodore Tegos
+* Thomas Düllmann
+* Thomas Spellman
+* Thunderspeed
+* Toshi
+* Emmanuel SELLIER
+* Vineet Deo
+* Walter L Schwartz
+* Wayne Mery
+* will
+* Wolf-Martell Montwé
+* Yury Ivanovich

--- a/electoral_rolls/2023.md
+++ b/electoral_rolls/2023.md
@@ -27,7 +27,6 @@ Electoral roll as of January 10, 2024.
 * Ben Campbell
 * Berna Alp
 * Besnik Bleta
-* Besnik Bleta
 * Brendan Abolivier
 * Brian Behlendorf
 * Brummolix
@@ -59,6 +58,7 @@ Electoral roll as of January 10, 2024.
 * Elizabeth Mitchell
 * Emilio Cobos Álvarez
 * Emmanuel ROECKER
+* Emmanuel SELLIER
 * Era
 * Erosman
 * Florent Tassy
@@ -128,7 +128,7 @@ Electoral roll as of January 10, 2024.
 * Philipp Kewisch
 * Philippe Lieser
 * Philippe Vigneau
-* Phoenix
+* Phoenix 
 * Ping Chen
 * Raymond Hill
 * Rhoslyn Prys
@@ -154,7 +154,6 @@ Electoral roll as of January 10, 2024.
 * Thomas Spellman
 * Thunderspeed
 * Toshi
-* Emmanuel SELLIER
 * Vineet Deo
 * Walter L Schwartz
 * Wayne Mery


### PR DESCRIPTION
This is the currently election roll as of January 10, 2024.