### PR TITLE
Add (generated) motion history

### DIFF
--- a/MOTIONS.md
+++ b/MOTIONS.md
@@ -1,0 +1,426 @@
+# Council Motion History
+Council motions are used for formal decision making in the Thunderbird Council. See the [bylaws](https://github.com/thunderbird/council-docs/blob/main/BY_LAWS.md#decision-making-process) for more information. This document captures the formal decisions that have been made, which go beyond informal discussion that can happen in addition.
+
+## 2024-2025
+
+**Term**: Ongoing since February 02, 2024
+
+**Council Members:**
+- Danny Colin (Chair)
+- Kai Engert (Secretary)
+- Bogomil Shopov (until August 12, 2024)
+- John Bieling
+- Patrick Cloke
+- Philipp Kewisch
+- Teal Dulcet
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>Proposal to approve the 2025 Thunderbird Mobile Roadmap
+See <a href="https://docs.google.com/document/d/14Kc2-tTXmAAVGBSdw-1E7d5xd5KnI6Q7Kmwal9G70vc/edit">2025 Product Strategy - Mobile</a></p></td><td valign="top">2025-03-21<br>Proposed: Kai<br><br>Seconded: Philipp</td><td valign="top">Yes: Danny, John, Kai, Patrick<br><br>No: Teal<br><br>Abstain: Philipp</td><td valign="top"><details><summary>Philipp</summary><p>(conflict of interest, mobile manager) I shall note that I do not agree with the assessment that the matter was not sufficiently discussed. There was ample opportunity to discuss within and outside of council meetings, and the proposed amendments apparently did not receive support from other council members.</p></details><br><details><summary>Teal</summary><p>While I support the iOS part of the roadmap, as well as the investments in stability and correctness on Android, by voting on this mobile roadmap without holding any meetings with the Council or negotiations with MZLA as I requested, as well as not meaningfully including any of our other six goals or considering any of my amendments, the one sided roadmap is overall very disrespectful of the community, which will set Thunderbird on Android back another year on much needed changes, including switching to Mozilla's GeckoView browser engine to allow direct code sharing with desktop.</p></details></td></tr>
+<tr><td valign="top"><p>Proposal to approve the revised 2025 Thunderbird Desktop Roadmap
+See <a href="https://docs.google.com/document/d/14BLIAGgTjprRONCFZFffIfYJZEVfK6jD5OcJ40DWZQs/edit">2025-2026 Product Roadmap - Desktop</a></p></td><td valign="top">2025-03-20<br>Proposed: Philipp<br><br>Seconded: Danny</td><td valign="top">Yes: Danny, John, Kai, Patrick, Philipp<br><br>No: Teal</td><td valign="top"><details><summary>Philipp</summary><p>I shall note that I do not agree with the assessment that goals were not sufficiently taken into account, especially given the timing of sharing the council goals. The proposed amendments apparently did not receive support from other council members.</p></details><br><details><summary>Teal</summary><p>While the addition of initial work on Chat is a welcome improvement, by not meaningfully including any of our other six goals or considering any of my amendments, the one sided roadmap is overall very disrespectful of the community, which will set Thunderbird back another year on much needed changes.</p></details></td></tr>
+<tr><td valign="top"><p>Approve 2025 budget as provided by Ryan</p></td><td valign="top">2025-02-13<br>Proposed: Patrick<br><br>Seconded: Danny</td><td valign="top">Yes: Danny, John, Kai, Patrick, Philipp<br><br>No: Teal</td><td valign="top"><details><summary>Teal</summary><p>While MZLA did provide a single page high level overview of their proposed budget with breakdowns by category/department, it did not provide enough information for me to make an informed decision, including the itemized amounts, which I requested, or the final amount of the Council budget.</p></details></td></tr>
+<tr><td valign="top"><p>Proposal to change the election rules
+See <a href="https://docs.google.com/document/d/1wxyzftPFy2ulhJa8E_5fbwbsqVVv5-90S6b7YTzTLZ8/edit">election rule updates</a>.</p></td><td valign="top">2025-01-09<br>Proposed: Danny<br><br>Seconded: Kai</td><td valign="top">Yes: Danny, John, Kai, Patrick, Philipp, Teal</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Update the Thunderbird Module owners as follows (by module). Note that “removed” positions
+automatically go to the emeritus status.</p>
+<ul>
+<li>
+<p>Thunderbird Council:</p>
+<ul>
+<li>Remove Bogomil Shopov</li>
+</ul>
+</li>
+<li>
+<p>Thunderbird Desktop:</p>
+<ul>
+<li>Add Alessandro Castellani as peer</li>
+<li>Remove Aceman as peer</li>
+</ul>
+</li>
+<li>Build Config:<ul>
+<li>Add Daniel Darnell as peer</li>
+<li>Remove Philipp Kewisch as peer</li>
+</ul>
+</li>
+<li>Theme:<ul>
+<li>Promote Alessandro Castellani from peer to owner</li>
+</ul>
+</li>
+<li>UX:<ul>
+<li>Remove Henry Wilkes as peer</li>
+</ul>
+</li>
+<li>
+<p>Calendar:</p>
+<ul>
+<li>Add Sean Burke as peer</li>
+</ul>
+</li>
+<li>
+<p>Mail and News Core</p>
+<ul>
+<li>Remove Joshua Cranmer as owner</li>
+<li>Add Thunderbird Council as owner</li>
+<li>Remove Aceman as peer</li>
+</ul>
+</li>
+<li>Addressbook<ul>
+<li>Remove Aceman as peer</li>
+</ul>
+</li>
+<li>Add new Exchange module<ul>
+<li>Add Sean Burke as owner</li>
+<li>Add Brendan Abolivier as peer</li>
+</ul>
+</li>
+<li>Feeds<ul>
+<li>Remove alta88 as peer</li>
+</ul>
+</li>
+<li>MIME Parser<ul>
+<li>Remove Jim Porter as peer</li>
+<li>Remove Joshua Cranmer as peer</li>
+</ul>
+</li>
+<li>Message Database<ul>
+<li>Remove Aceman as peer</li>
+<li>Remove Joshua Cranmer as peer</li>
+<li>Add Ben Campbell as owner</li>
+</ul>
+</li>
+<li>News<ul>
+<li>Remove Joshua Cranmer as owner</li>
+</ul>
+</li>
+<li>Remove duplicated S/MIME under Mail and News Core (It already exists under Thunderbird Desktop)</li>
+<li>SMTP<ul>
+<li>Remove Ping Chen as owner</li>
+</ul>
+</li>
+<li>Unit Testing Infrastructure<ul>
+<li>Remove Joshua Cranmer as peer</li>
+</ul>
+</li>
+</ul>
+<p>Peers and owners which were removed are removed due to no longer contributing to the
+project in that capacity, with the exception of the Thunderbird Council, where Bogomil had
+previously stepped down.</p></td><td valign="top">Date unknown<br>Proposed: Patrick<br><br>Seconded: Philipp</td><td valign="top">Yes: Danny, John, Kai, Patrick, Philipp, Teal</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>The council supports a strategic initiative proposal by MZLA regarding upcoming Thunderbird services. The council added conditions to enable more users to benefit, as well as providing more information to the public on why this decision was made, should MZLA decide to move forward with this initiative.</p></td><td valign="top">2024-05-21<br>Proposed: Danny<br><br>Seconded: Philipp</td><td valign="top">Yes: Bogo, Danny, John, Kai, Patrick, Philipp, Teal</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Direct MZLA update their policy to regularly review and integrate select patches from prominent TB forks into Thunderbird. Any integrated patches should be attributed to the fork, but this should require NO interaction with any volunteers from the fork.</p></td><td valign="top">2024-04-04<br>Proposed: Teal<br><br>Seconded: Bogo</td><td valign="top">Yes: Teal<br><br>No: Kai, Patrick, Philipp<br><br>Abstain: Bogo, Danny, John</td><td valign="top"></td></tr>
+</table>
+
+## 2022-2024
+
+**Term**: December 20, 2022 to February 24, 2024
+
+**Council Members:**
+- Berna Alp (Chair)
+- Patrick Cloke (Secretary)
+- Ben Bucksch
+- Danny Colin
+- John Bieling
+- Micah Ilbery
+- Philipp Kewisch
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>Approve the <a href="https://docs.google.com/document/d/1Lgt0sBpScL5_wySrrT966-yKFz2s_Yf5q4cwPseHc7A/edit">Thunderbird Council Bylaws</a>. See also <a href="https://docs.google.com/spreadsheets/d/1TmiEkfpvmpoaOkcOBHZhAqCD8nT_HeCxLVxb_mgF9fM/edit">Bylaws Voting Record</a>.</p></td><td valign="top">2023-12-12<br>Proposed: Patrick<br><br>Seconded: Micah</td><td valign="top">Yes: Berna, Danny, John, Micah, Patrick, Philipp<br><br>Abstain: Ben</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>The council agrees to follow Mozilla and redirect users from the module ownership page of the old Mozilla wiki to the new in-tree documentation.</p></td><td valign="top">2023-10-18<br>Proposed: John<br><br>Seconded: Berna</td><td valign="top">Yes: Ben, Berna, Danny, John, Micah, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Foremost, Thunderbird remains committed to its focus on decentralized, open-standard
+communication and being a significant driver of freedom on the Internet. We further recognize
+the need for interoperability, and feel this also extends to situations where the user is
+limited in choice by others, such as their system administrator. In alignment with this, our
+objective is to extend the reach of the Project and to engage with users even on proprietary
+protocols.</p>
+<p>Therefore, we support the request from MZLA to explore seamless integration of
+non-standard protocols such as Exchange for use in situations where open-standard protocols
+are not available.</p>
+<p>The MZLA team shall investigate viable implementation strategies and
+collaborate with the council and community to find an experience that is in line with the
+Thunderbird mission.</p></td><td valign="top">2023-08-07<br>Proposed: John, Philipp<br><br>Seconded: Micah</td><td valign="top">Yes: Berna, Danny, John, Micah, Patrick, Philipp<br><br>No: Ben</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>In response to the persisting technical issues with our current systems, the Council shall transition back to the reliable and established tools provided by MZLA for all file storage, collaboration on meeting notes, task organization, and video meetings. While acknowledging that such changes might present some inconvenience, we firmly believe that the overall functionality and stability of the MZLA tools outweigh these discomforts.</p></td><td valign="top">2023-08-07<br>Proposed: Philipp<br><br>Seconded: Danny</td><td valign="top">Yes: Danny, John, Micah, Patrick, Philipp<br><br>No: Ben, Berna</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Let Thunderbird project become member of Matrix Foundation, on Silver level, with 2000 USD/year</p></td><td valign="top">2023-07-10<br>Proposed: Danny<br><br>Seconded: Ben</td><td valign="top">Yes: Ben, Berna, Danny, John</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Investigate to use Jitsi for Community meetings, and Council meetings.</p></td><td valign="top">2023-07-10<br>Proposed: Ben<br><br>Seconded: John</td><td valign="top">Yes: Ben, Berna, Danny, John, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Move hostname nextcloud.thunderbird.net to IONOS (DNS at thunderbird.net, configure NextCloud at IONOS to the new hostname)</p></td><td valign="top">2023-07-10<br>Proposed: John<br><br>Seconded: Ben</td><td valign="top">Yes: Ben, Berna, Danny, John, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Module Ownership Change: Approve the change to the Thunderbird Desktop module made by Ryan Sipes, to make Thunderbird Council the owner of Thunderbird Desktop, and make Magnus a peer.</p></td><td valign="top">2023-07-03<br>Proposed: Berna<br><br>Seconded: Micah</td><td valign="top">Yes: Ben, Berna, Danny, John, Micah</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Ben propose that the Thunderbird Council post the following statement to the IETF mailing
+list:</p>
+<p>“The Thunderbird project would like to support this effort. We have been following
+this and think easy-to-use machine readable information in email is a relevant and
+important problem to address.</p>
+<p>We support the creation of Internet standards for this goal,
+and the creation of an IETF working group for this subject. While we have to await the
+resulting standards before deciding on concrete implementations, there's interest by
+Thunderbird to eventually support resulting RFCs in our mobile and desktop clients. Some
+individuals may also get involved in writing or commenting on the proposed specs.”</p></td><td valign="top">2023-06-12<br>Proposed: Ben<br><br>Seconded: Berna</td><td valign="top">Yes: Ben, Berna, Danny, John, Micah</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Propose to record council meetings with a retention period of [TBD].</p></td><td valign="top">2023-03-27<br>Proposed: Danny<br><br>Seconded: Ben</td><td valign="top">Yes: Berna, Danny, John, Micah, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve <a href="https://nextcloud.thunderbird.net/f/10800">MZLA/Thunderbird FY23 Budget</a>.</p></td><td valign="top">2023-02-06<br>Proposed: Patrick<br><br>Seconded: Danny, John</td><td valign="top">Yes: Berna, Danny, John, Micah, Patrick<br><br>No: Ben</td><td valign="top"></td></tr>
+</table>
+
+## 2021–2022
+
+**Term**: October 28, 2021 to December 20, 2022
+
+**Council Members:**
+- Berna Alp (Chair)
+- Andrei Hajdukewycz (Secretary)
+- Ben Bucksch
+- Dirk Steinmetz
+- Magnus Melin
+- Patrick Cloke
+- Philipp Kewisch
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>Allow new council members to see previous term’s Council meeting notes, unless there’s a specific, localized issue regarding a specific new Councilor. Such an issue must be proposed by 4 Councilors.</p></td><td valign="top">2022-12-05<br>Proposed: Ben<br><br>Seconded: Berna</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Offer a one-time surprise bonus to all employees. Lisa will work out the details together
+with the board. The amount will stay within the existing budget.</p>
+<p>Note: This motion wasn't technically required to use money within the existing budget.</p></td><td valign="top">2022-12-05<br>Proposed: Berna<br><br>Seconded: Dirk</td><td valign="top">Yes: Ben, Berna, Dirk, Patrick<br><br>Abstain: Andrei</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Publish the role of the Thunderbird Project Election Observer on GitHub.</p></td><td valign="top">2022-10-24<br>Proposed: Berna<br><br>Seconded: Dirk</td><td valign="top">Yes: Berna, Magnus, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Add <a href="https://wiki.mozilla.org/Thunderbird/Council_Election">Thunderbird Election Process</a> to the council-docs repository as the start of a Thunderbird Council bylaws document.</p></td><td valign="top">2022-08-01<br>Proposed: Patrick<br><br>Seconded: Dirk</td><td valign="top">Yes: Ben, Berna, Dirk, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Vote on the final version of the Operational Rules term sheet and announce it to the community via council meeting minutes and publish it on GitHub, wiki, Thunderbird website.</p></td><td valign="top">2022-08-01<br>Proposed: Berna<br><br>Seconded: Patrick</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick, Philipp<br><br>No: Ben</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve Conflict Resolution document to be submitted to the board along with Term Sheet.</p></td><td valign="top">2022-08-01<br>Proposed: Berna<br><br>Seconded: Patrick</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Acquire K-9 Mail and all its Intellectual Property assets and accounts, as set out by the contracts created by MZLA legal.</p></td><td valign="top">Date unknown<br>Proposed: Ben, Berna<br><br>Seconded: Philipp</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Patrick, Philipp<br><br>Abstain: Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Keep conflict resolution clause in the document, noting that we would like to have one, but will define it separately. This is as opposed to removing it and implying that we do not need a conflict resolution statement.</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Patrick, Philipp<br><br>No: Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve section "c" beginning with "The oversight of the staff leadership team will be managed as follows..."</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve section b in the sheet starting with "The oversight of the funds collected..."</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Change to and approve: “Changes of more than 30% per budget category or 10% of the whole budget, whichever is less, up or down within major budget categories, and/or budget reallocations between budget categories require majority approval by each of the Council and the MZLA Board.”</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Magnus, Patrick, Philipp<br><br>No: Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve the term sheet section "The full Thunderbird Council" section a, I-iii, ending "on the product road map."</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Vote to approve the text block starting “MZLA Technologies, represented by the MZLA Board, is responsible for:” in the term sheet.</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Change sentence to "The Council plays an advisory role to the MZLA Board in setting yearly goals for the staff on the staff leadership team."</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Dirk, Magnus, Patrick<br><br>No: Berna</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Replace “OKRs” in the term sheet with the term “goals”</p></td><td valign="top">2022-05-16<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Dirk, Magnus, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>On term sheet sentence: "Stewardship of the funds collected through Thunderbird donations and new business lines that relate directly to Thunderbird" vs. "...new business lines that result from those funds", replace "new business lines that relate directly to Thunderbird" with "...new business lines that result from those funds."</p></td><td valign="top">2022-05-09<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Magnus<br><br>No: Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Motion on re-org term sheet: Discussion about the sentence "The Thunderbird project including product strategy, technology, ..." - Keep "technology" in the sentence.</p></td><td valign="top">2022-05-09<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Ben, Ben, Berna, Dirk, Magnus<br><br>No: Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Motion on sentence in re-org term sheet:</p>
+<ul>
+<li>Version A (NO): “The Thunderbird project is stewarded by the Thunderbird Council and
+  assisted by MZLA Technologies”</li>
+<li>Version B (YES): “The Thunderbird project is jointly stewarded by the Thunderbird
+  Council and MZLA Technologies”</li>
+</ul></td><td valign="top">2022-05-09<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Berna, Magnus, Patrick, Philipp<br><br>No: Ben, Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>The Thunderbird Council module is hierarchically above Thunderbird desktop and Thunderbird mobile, and the Thunderbird Council is the highest org. Once we start work on Thunderbird mobile, there will be a new top-level module for Thunderbird mobile, which is parallel to Thunderbird desktop.</p></td><td valign="top">2022-04-25<br>Proposed: Ben<br><br>Seconded: Berna</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Patrick<br><br>No: Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>On Council bylaws: We start with a blank sheet. Dirk is leading the process of creating the document. We decide with a Council motion which rules are part of the process. These motions may be individual rules or a larger section of the document.</p></td><td valign="top">2022-04-11<br>Proposed: Ben<br><br>Seconded: Dirk</td><td valign="top">Yes: Ben, Berna, Dirk<br><br>No: Andrei, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Create a new public repository at https://github.com/thundernest/council-docs with the description 'Official repository for organizational matters regarding the Thunderbird council, the elected body governing the Thunderbird project' and give all councilors that both have GitHub accounts and are interested administrative access to that repository. The repository features 'Wikis', 'Issues', 'Sponsorships', 'Projects', 'Discussions' must be disabled. The repository's main branch and settings must not be changed by anyone, unless there is an explicit council motion requesting the specific change. Any councilor may revert and/or publicly report changes that were not performed in accordance with a council motion.</p></td><td valign="top">2022-04-11<br>Proposed: Dirk<br><br>Seconded: Magnus</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Magnus, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Start negotiations and prepare contracts for MZLA acquire K-9 including brand assets, including donation cash flow. The full contracts are to be presented to the council for final approval. Negotiators shall immediately communicate any unforeseen details.</p></td><td valign="top">2022-02-28<br>Proposed: Berna<br><br>Seconded: Ben</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk<br><br>Abstain: Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Have a community discussion asking about mobile clients in general, but not mentioning K-9, asking: How would they like the mobile client to look like? Native client? What is important for you in it?</p></td><td valign="top">2022-01-31<br>Proposed: Dirk<br><br>Seconded: Unknown</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk<br><br>Abstain: Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>As general direction, but not as business strategy:
+"Thunderbird: Secure and build on position by
+(a) ensuring continued product/market fit (e.g., mobile, enterprise), and
+(b) ensuring financial health by building/integrating value added services and monetizing
+    through subscription or enhanced donation mechanics"</p></td><td valign="top">2022-01-31<br>Proposed: Berna<br><br>Seconded: Andrei</td><td valign="top">Yes: Andrei, Berna, Magnus, Patrick, Philipp<br><br>No: Ben, Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>The Council requests that the MZLA board perform due diligence with the intent to acquire K9 mail. Once the board has done this, they will report their findings to the Council, and a separate motion will decide how and whether the acquisition will be finalized.</p></td><td valign="top">2022-01-10<br>Proposed: Andrei<br><br>Seconded: Ben</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Patrick, Philipp<br><br>No: Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approve and adopt the 2022 Budget with the intent to review it.</p></td><td valign="top">2022-01-10<br>Proposed: Berna<br><br>Seconded: Magnus</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to onetime bonus payout with specific amounts/terms.</p></td><td valign="top">2022-01-10<br>Proposed: Berna<br><br>Seconded: Ben</td><td valign="top">Yes: Ben, Berna<br><br>No: Dirk, Patrick, Philipp<br><br>Abstain: Andrei, Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Give employees Dec 23 - Jan 3 off without using PTO, conditional on MoFo telling us how to handle it with all employees/contractors.</p></td><td valign="top">2021-12-06<br>Proposed: Andrei<br><br>Seconded: Philipp</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Patrick, Philipp<br><br>Abstain: Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Motion to contract a web designer for a new design for the Thunderbird blog.</p></td><td valign="top">2022-11-22<br>Proposed: Berna<br><br>Seconded: Philipp</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Ben will take meeting notes and will provide to the council list and provide 24 hours if something is factually incorrect. If there is an objection, we expand to 72 hours after the meeting. If there is an issue that is contentious, this issue is mentioned as redacted because somebody objected.  It will then be posted even if there is further discussion necessary. They will then be posted to be tb-planning.</p></td><td valign="top">2021-11-22<br>Proposed: Ben<br><br>Seconded: Berna, Dirk</td><td valign="top">Yes: Andrei, Ben, Berna, Dirk<br><br>No: Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+</table>
+
+## 2020–2021
+
+**Term**: October 16, 2020 to October 28, 2021
+
+**Council Members:**
+- Philipp Kewisch (Chair)
+- Ryan Sipes (Treasurer)
+- Patrick Cloke (Secretary)
+- Berna Alp
+- Christopher Leidigh
+- Dirk Steinmetz
+- Magnus Melin
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Delegate contract renewals to MZLA. Managers may renew contracts of their reports up to a certain % raise per year.</p></td><td valign="top">2021-11-08<br>Proposed: Ryan<br><br>Seconded: Berna</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Formally delegate expenses, reporting for tax purposes, reviewing (sanity-checking) employee expense sheets, etc off of the Treasurer/Council to Ryan (MZLA).</p></td><td valign="top">2021-11-08<br>Proposed: Dirk<br><br>Seconded: Berna</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick<br><br>Abstain: Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Delegate contract renewals: Managers may renew contracts of their reports with up to 4% raise per year.</p></td><td valign="top">2021-11-08<br>Proposed: Ryan<br><br>Seconded: Berna</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract.</p></td><td valign="top">2021-11-08<br>Proposed: Magnus<br><br>Seconded: Ryan</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract.</p></td><td valign="top">2021-11-08<br>Proposed: Magnus<br><br>Seconded: Ryan</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to contract design system review from Ura Design</p></td><td valign="top">2021-09-27<br>Proposed: Ryan<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>For the current election cycle, make the mailing list elections run on publicly readable on discuss.thunderbird.net (Topicbox). Posting shall remain limited to people in the electorate, with the existing restrictions outside of the discussion phase.</p></td><td valign="top">2021-09-27<br>Proposed: Dirk<br><br>Seconded: Philipp</td><td valign="top">Yes: Berna, Dirk<br><br>No: Christopher, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Team re-org (August 2021): Promotion to team lead</p></td><td valign="top">2021-09-13<br>Proposed: Magnus<br><br>Seconded: Unknown</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Ryan<br><br>Abstain: Dirk, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Team re-org (August 2021): Change the reporting structure under Magnus to be as in the chart, as of September 1.</p></td><td valign="top">2021-09-13<br>Proposed: Ryan<br><br>Seconded: Berna</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Ryan<br><br>Abstain: Dirk, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Contract with Jane Silber for business development consulting.</p></td><td valign="top">2021-08-16<br>Proposed: Philipp<br><br>Seconded: Christopher</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Philipp, Ryan<br><br>Abstain: Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contracting with a specific individual.</p></td><td valign="top">2021-08-02<br>Proposed: Magnus<br><br>Seconded: Christopher</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus<br><br>No: Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Team re-org (July 2021). Note - this was later revised.</p></td><td valign="top">2021-07-19<br>Proposed: Magnus<br><br>Seconded: Ryan</td><td valign="top">Yes: Berna, Christopher, Magnus, Ryan<br><br>No: Philipp<br><br>Abstain: Dirk</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to performance review.</p></td><td valign="top">2021-06-21<br>Proposed: Magnus<br><br>Seconded: Unknown</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to convert a contractor to full time.</p></td><td valign="top">2021-06-21<br>Proposed: Magnus<br><br>Seconded: Christopher</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract for 6 months.</p></td><td valign="top">2021-06-07<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Agreement on and publishing of the below texts for preamble and mission.</p>
+<ul>
+<li>
+<p>Preamble: Email has been and continues to be the fundamental communication tool and
+  a significant driver of freedoms on the Internet. But it is also   threatened by new
+  non-standards-based, closed and centralized messaging platforms. To prevent this
+  erosion, the public deserves an alternative that is secure and reliable, while
+  protecting our privacy, enhancing our productivity and serving as a platform for
+  current and future forms of messaging.</p>
+</li>
+<li>
+<p>Mission: Thunderbird facilitates cross platform, decentralized, open-standard
+  communication, which puts the user in control of their data and  workflow. We aspire
+  to offer an interoperable and extensible open-source platform for messaging and
+  managing personal information, such as email, contacts, and appointments.</p>
+</li>
+</ul></td><td valign="top">2021-05-10<br>Proposed: Berna<br><br>Seconded: Unknown</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract for 6 months.</p></td><td valign="top">2021-04-26<br>Proposed: Magnus<br><br>Seconded: Christopher</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract for 6 months.</p></td><td valign="top">2021-04-26<br>Proposed: Magnus<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract for 6 months.</p></td><td valign="top">2021-04-26<br>Proposed: Magnus<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to employee benefits for an individual.</p></td><td valign="top">2021-04-26<br>Proposed: Magnus<br><br>Seconded: Dirk</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to MZLA employee benefits as a whole.</p></td><td valign="top">2021-03-09<br>Proposed: Magnus<br><br>Seconded: Berna, Patrick</td><td valign="top">Yes: Berna, Christopher, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to bonus pay.</p></td><td valign="top">2021-03-15<br>Proposed: Ryan<br><br>Seconded: Dirk</td><td valign="top">Yes: Berna, Dirk, Magnus, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Fix voting records motion: can we agree on a new phrasing replacing the motion from
+2020-09-28:</p>
+<p>Publish the complete voting record of all council members on all motions excluding motions
+containing PII and confidential information in the regular minutes.</p></td><td valign="top">2021-02-01<br>Proposed: Dirk<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contracting through a third party.</p></td><td valign="top">2021-02-01<br>Proposed: Philipp<br><br>Seconded: Magnus</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contracting and employment.</p></td><td valign="top">2021-02-01<br>Proposed: Philipp<br><br>Seconded: Magnus</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>The council should not make major strategic or organizational decisions, including but not limited to restructuring the project or significantly changing policies for public services or products, without having had at least 7 days of public discussion regarding the specific decision. These discussions are announced on tb-planning, but can occur on any public discussion channel.</p></td><td valign="top">2021-02-01<br>Proposed: Dirk<br><br>Seconded: Berna</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Ryan<br><br>Abstain: Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Approve hiring two more developers.</p></td><td valign="top">2021-02-01<br>Proposed: Magnus<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan<br><br>Abstain: Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Approve hiring two developers.</p></td><td valign="top">2020-12-17<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Extend an existing contract.</p></td><td valign="top">2020-12-10<br>Proposed: Magnus<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Christopher, Dirk, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to renew a vendor contract for a year.</p></td><td valign="top">2020-12-07<br>Proposed: Magnus<br><br>Seconded: Unknown</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Adopt and experiment with Council;DR as outlined above and in slides (to save time, vote with your preference on how information is shared)</p></td><td valign="top">2020-11-23<br>Proposed: Dirk<br><br>Seconded: Ryan</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Ryan</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Various contract renewals.</p></td><td valign="top">2020-11-09<br>Proposed: Dirk<br><br>Seconded: Ryan</td><td valign="top">Yes: Berna, Christopher, Dirk, Magnus, Patrick, Philipp, Ryan</td><td valign="top"></td></tr>
+</table>
+
+## 2019–2020
+
+**Term**: March 21, 2019 to October 16, 2020
+
+**Council Members:**
+- Philipp Kewisch (Chair)
+- Ryan Sipes (Treasurer)
+- Wayne Mery (Secretary)
+- Berna Alp
+- Jörg Knobloch
+- Magnus Melin
+- Patrick Cloke
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>Publish the document <a href="https://docs.google.com/document/d/1mtJ7J7J2A_NGuQ8wMxv6eR1Z946fvaIqIZVGU2OdSbw/edit">Thunderbird Election Process</a> publicly on the Mozilla Wiki.</p></td><td valign="top">2020-09-28<br>Proposed: Patrick<br><br>Seconded: Unknown</td><td valign="top">Yes: Berna, Magnus, Patrick, Philipp, Ryan, Wayne</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Publish the complete voting record of all council members on all motions excluding PII and confidential information in the regular minutes.</p></td><td valign="top">2020-09-28<br>Proposed: Berna<br><br>Seconded: Ryan</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion was made related to a CPG action.</p></td><td valign="top">2020-07-27<br>Proposed: Philipp<br><br>Seconded: Wayne</td><td valign="top">Yes: 5<br><br>Abstain: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion was made related to a CPG action.</p></td><td valign="top">2020-06-09<br>Proposed: Philipp<br><br>Seconded: Magnus</td><td valign="top">No: Berna, Magnus, Patrick, Philipp, Ryan, Wayne</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Hand over the Quicktext Add-On ownership to its de facto maintainer John Bieling from the Thunderbird Development Team.</p></td><td valign="top">2020-03-10<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: Berna, Jörg, Magnus, Patrick, Philipp, Ryan, Wayne</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>NDA Visibility: The agreement will not be made available publicly. It shall be made available to candidates that are standing for election once the discussion period is over</p></td><td valign="top">2020-02-28<br>Proposed: Philipp<br><br>Seconded: Patrick</td><td valign="top">Yes: Jörg, Magnus, Patrick, Philipp, Ryan, Wayne<br><br>No: Berna</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Requiring the NDA</p>
+<ul>
+<li>The Mozilla NDA will be made a requirement for serving on the Thunderbird Council</li>
+<li>The requirement will be communicated as part of the election process, before candidates
+  stand for election.</li>
+<li>The voting occurs and results are gathered. Candidates that pass the vote sign the NDA.</li>
+<li>If one or more candidates do not sign the NDA, a second vote occurs with remaining
+  candidates. For one remaining candidate it is a yes/no vote, otherwise the same method
+  as for the council vote.</li>
+</ul></td><td valign="top">2020-02-28<br>Proposed: Philipp<br><br>Seconded: Patrick</td><td valign="top">Yes: Jörg, Magnus, Patrick, Philipp, Ryan, Wayne<br><br>No: Berna</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Approval for the “Thunderbird job requisites late 2019”</p></td><td valign="top">2019-12-05<br>Proposed: Magnus<br><br>Seconded: Wayne</td><td valign="top">Yes: 5<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>FOSDEM 2020 (approve costs for three people)</p></td><td valign="top">2019-12-05<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contract extension.</p></td><td valign="top">2019-12-05<br>Proposed: Magnus<br><br>Seconded: Ryan</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Remove exchange option for free accounts (Hotmail/Outlook). Remove exchange option for Office365 as well - “back to original terms”.</p></td><td valign="top">2019-11-14<br>Proposed: Philipp<br><br>Seconded: Unknown</td><td valign="top">Yes: 5<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Until a further motion amends it, the roles are filled as follows:</p>
+<ul>
+<li>Ryan assumes the operations role, pending his acceptance.</li>
+<li>Philipp assumes the main point of contact role.</li>
+</ul></td><td valign="top">2019-10-10<br>Proposed: Philipp<br><br>Seconded: Patrick</td><td valign="top">Yes: 5</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Parts of Thunderbird that are add-ons for technical reasons that are developed by the Thunderbird project do not require approval by the Thunderbird Council.</p></td><td valign="top">2019-05-05<br>Proposed: Jörg<br><br>Seconded: Ryan</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Any new third party add-on to be shipped in Thunderbird will need to be approved by the Thunderbird Council. The Lightning and WeTransfer add-ons are grandfathered in.</p></td><td valign="top">2021-11-08<br>Proposed: Ryan<br><br>Seconded: Berna</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Passed External Transparency reporting - this will make it so that Council meeting notes are shared regularly with some things held back because for confidentiality purposes.</p></td><td valign="top">2019-08-22<br>Proposed: Berna, Philipp<br><br>Seconded: Berna, Patrick</td><td valign="top">Yes: 4</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contract extensions</p></td><td valign="top">2019-07-25<br>Proposed: Jörg<br><br>Seconded: Philipp</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to contract extension for 6 month</p></td><td valign="top">2019-07-10<br>Proposed: Magnus<br><br>Seconded: Jörg</td><td valign="top">Yes: 6<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to adjusting a contractor rate.</p></td><td valign="top">2019-07-10<br>Proposed: Magnus, Ryan<br><br>Seconded: Philipp, Wayne</td><td valign="top">Yes: 4</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to a contract extension.</p></td><td valign="top">2019-06-20<br>Proposed: Magnus<br><br>Seconded: Ryan</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to a contract extension.</p></td><td valign="top">2019-05-30<br>Proposed: Magnus<br><br>Seconded: Berna</td><td valign="top">Yes: 5</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to a contract extension.</p></td><td valign="top">2019-05-30<br>Proposed: Magnus<br><br>Seconded: Unknown</td><td valign="top">Yes: 5</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>The Council agrees to explore the Thunderbird LLC as the primary option forward, organizationally. We will convey this to MoFo and continue discussion to explore the specifics of how the LLC will be set up. Further voting will occur when there are concrete items to decide on, e.g. a contract.</p></td><td valign="top">2019-04-25<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Swag/Promotion Budget Approval</p></td><td valign="top">2019-04-25<br>Proposed: Ryan<br><br>Seconded: Wayne</td><td valign="top">Yes: 6</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to salary rates to account for local country benefits.</p></td><td valign="top">2019-04-16<br>Proposed: Philipp<br><br>Seconded: Wayne</td><td valign="top">Yes: 4</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to hiring a full time employee</p></td><td valign="top">2019-04-05<br>Proposed: Magnus<br><br>Seconded: Wayne</td><td valign="top">Yes: 4<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to hiring a contractor</p></td><td valign="top">2019-03-27<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: 7</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Change the title of Ryan Sipes to "Community and Business Development Manager". Define his new responsibilities and salary.</p></td><td valign="top">2019-03-24<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: 5</td><td valign="top"></td></tr>
+</table>
+
+## 2018–2019
+
+**Term**: March 31, 2018 to March 21, 2019
+
+**Council Members:**
+- Philipp Kewisch (Chair)
+- Ryan Sipes (Treasurer)
+- Wayne Mery (Secretary)
+- Jörg Knobloch
+- Magnus Melin
+- Patrick Cloke
+- Philippe Lieser
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to hiring an employee.</p></td><td valign="top">2019-03-21<br>Proposed: Magnus<br><br>Seconded: Wayne</td><td valign="top">Yes: 5<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>As clarification of the Council decision of 2018-01-31 stating that only two people of the same organization/association/unit or company can be nominated for election to the Thunderbird Council; The 'Mozilla Corporation' and the 'Mozilla Foundation' which serves as legal home of the independent 'Thunderbird Project' (and hence fiducially contracts staff for the project) are (considered) separate companies for purposes of "professional affiliation".</p></td><td valign="top">2019-03-13<br>Proposed: Wayne<br><br>Seconded: Patrick</td><td valign="top">Yes: Berna, Magnus, Philipp, Ryan<br><br>Abstain: Jörg, Patrick, Wayne</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>The Council agrees to allocate a budget of up to NNN in legal fees, per quarter. Accessing this budget doesn't require further votes, but the intent needs to be signaled to the council list, and informal approval needs to be obtained from one further council member.</p></td><td valign="top">2019-03-04<br>Proposed: Wayne<br><br>Seconded: Philipp</td><td valign="top">Yes: 6<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Sending Magnus and Kai to the Freiburg meetup with DeltaChat Feb 4-5th. Combined costs for Magnus with FOSDEM will be around 2000 EUR</p></td><td valign="top">2019-01-13<br>Proposed: Magnus<br><br>Seconded: Philipp</td><td valign="top">Yes: 6<br><br>No: 1</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Sending any European council member to FOSDEM, plus Ryan as community manager. Travel costs max 1250 EUR for European travelers, and 2250 EUR for international travelers</p></td><td valign="top">2019-01-08<br>Proposed: Philipp<br><br>Seconded: Wayne</td><td valign="top">Yes: 4</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Collaborate with BenB on getting this into account creation (non-exclusively), but no contract.</p></td><td valign="top">2018-11-20<br>Proposed: Ryan<br><br>Seconded: Wayne</td><td valign="top">Yes: 4</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to accepting a % rate to negotiate a partnership.</p></td><td valign="top">2018-07-18<br>Proposed: Ryan<br><br>Seconded: Unknown</td><td valign="top">Yes: 7</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>Spend an amount to pay a contractor for fixing the specific security bug(s). We will attempt to use the SOS funds, but if that is not possible we will use Thunderbird funds.</p></td><td valign="top">2018-06-06<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Move Ryan to full time status to increase hours devoted to current role, plus cross train with Andrei, plus interim build engineer (until we have hire an engineer), plus document web and engineer processes.</p></td><td valign="top">2018-05-30<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Request to make use of Matomoto website analytics at $140/month, minus 30% discount.</p></td><td valign="top">2018-05-13<br>Proposed: Ryan<br><br>Seconded: Philippe</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to hire a contractor</p></td><td valign="top">2018-05-09<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>WeTransfer - Consensus is to not enable in the release (or wait until a point release to ship) unless terms are agreed to.</p></td><td valign="top">2018-05-02<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to hire a contractor.</p></td><td valign="top">2018-04-27<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>“The Thunderbird Council agrees that the logo change presented in this thread is in the best interest of the product and requires no further changes. Once the original trademark owner (Mozilla) approves, the logo will be considered the new official Thunderbird logo and implemented in all properties</p></td><td valign="top">2018-04-27<br>Proposed: Ryan<br><br>Seconded: Philipp</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+</table>
+
+## 2017–2018
+
+**Term**: March 17, 2017 to March 31, 2018
+
+**Council Members:**
+- Philipp Kewisch (Chair)
+- R Kent James (Treasurer)
+- Ben Bucksch (until January 30, 2018)
+- Jörg Knobloch
+- Magnus Melin
+- Patrick Cloke
+- Ryan Sipes
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to hire a contractor at a rate TBD.</p></td><td valign="top">2018-03-14<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion to extend a contract</p></td><td valign="top">2018-03-07<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>New mailnews/ and mail/ module owners (makes decisions): Kent, Jörg, Magnus, Ben (removing jcranmer)</p></td><td valign="top">2017-06-23<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Maildev - create mailing list for discussion open to all developers (everybody who contributed code to TB).  Decision will be made by the 4 new module owners above. Module owners meet per video conference</p></td><td valign="top">2017-06-23<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Negotiate hiring community manager, rate TBD at Philipp’s (Chair’s) discretion</p></td><td valign="top">2017-05-19<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+<tr><td valign="top"><p>Add CardBook to the "Featured Add-ons" section of ATN</p></td><td valign="top">2017-04-14<br>Proposed: Unknown<br><br>Seconded: Unknown</td><td valign="top">Yes: Majority (unknown)</td><td valign="top"></td></tr>
+</table>
+
+## 2016–2017
+
+**Term**: March 01, 2016 to March 17, 2017
+
+There were more motions in this period, however we were just beginning to define a formal voting process and did not track them all. Exact term start is not known.
+
+**Council Members:**
+- Magnus Melin (Chair)
+- R Kent James (Treasurer)
+- Jörg Knobloch
+- Matt Harris
+- Patrick Cloke
+- Philipp Kewisch
+- Wayne Mery
+
+<table><tr><th>Motion</th><th>Details</th><th>Votes</th><th>Statements</th>
+<tr><td valign="top"><p>[CONFIDENTIAL - This motion was redacted/reworded for publishing]<br>A motion related to hiring a contractor</p></td><td valign="top">2017-03-09<br>Proposed: rkent<br><br>Seconded: Patrick</td><td valign="top">Yes: Jörg, Matt, Patrick, Philipp, Wayne, rkent</td><td valign="top"></td></tr>
+</table>
+
+## 2014–2016
+
+**Term**: 2014 to March 17, 2017
+
+We did not have a formal voting process in this period. rkent was reconfirmed as chair in July 2015.
+
+**Council Members:**
+- R Kent James (Chair)
+- Florian Quèze
+- Joshua Cranmer
+- Magnus Melin
+- Mike Conley
+- Philipp Kewisch
+- Wayne Mery
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# council-docs
-Official Thunderbird Council documents.
+# Thunderbird Council Documents
+
+* The [Term Sheet](./TERM_SHEET.md) defines the working relation between the Thunderbird Council and
+  MZLA
+* The [Bylaws](./BY_LAWS.md) describe how the council operates and is elected.
+* The [Motion History](./MOTIONS.md) is a record of all past motions that have been made.


### PR DESCRIPTION
This motion history is generated from a YAML file in a private repository. The YAML file contains the full motions with confidential details unredacted. This way we can maintain them in one spot, while making a public version available.

What I didn't include from the original motion history doc is:

* Motions that received no vote because they were abandoned
* Motions that received no second, because we didn't consistently include these
* Indicating who voted for whom as chair/secretary/etc

The term dates are guesstimated based on the tb-election list. There are a few more motions hidden in emails somewhere, but we simply don't have good data 2014-2017.
