### PR TITLE
Update Council role term-length to 1 year

### DIFF
--- a/BY_LAWS.md
+++ b/BY_LAWS.md
@@ -124,6 +124,8 @@ Each councilor is elected for a two year term during the council election.
 
 ### Roles
 
+Council roles are elected by the Council. Each role has a 1-year term.
+
 #### Chairperson
 
 Organize the work of the Thunderbird Council and encourage members to do the same


### PR DESCRIPTION
Per the changes in https://www.notion.so/mzthunderbird/Re-elect-chair-after-1-year-has-passed-1c32df5d45ae80fcac22f212701eb7e0 as were voted on 2025-05-13.

This was proposed by @mkmelin and seconded by @kewisch and passed unanimously by:

* @kewisch 
* @tdulcet 
* @clokep
* @mkmelin
* @micz 
* @timmaks